### PR TITLE
Connec to Ares

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/sirupsen/logrus v1.9.3
-	github.com/stesla/telnet v0.3.1
+	github.com/stesla/telnet v0.3.2
 	golang.org/x/text v0.11.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/stesla/telnet v0.3.1 h1:ZtFO7ytp0s5D9+dmZCZJzguoc7C8QH5Be/eIHRBKkUY=
-github.com/stesla/telnet v0.3.1/go.mod h1:ytGnHzD0//3Y322aqKip+xtvh+dhdBfB3jl2LDGc82I=
+github.com/stesla/telnet v0.3.2 h1:VW/cA6k71r1SBJ3KRg7LxO319W+6pfa2BIkcC+Ekfjc=
+github.com/stesla/telnet v0.3.2/go.mod h1:ytGnHzD0//3Y322aqKip+xtvh+dhdBfB3jl2LDGc82I=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/main.go
+++ b/main.go
@@ -67,11 +67,15 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		conn := telnet.Server(tcpconn)
+		logger := newLogrusLogger(log, logrus.Fields{
+			"type": "client",
+			"peer": tcpconn.RemoteAddr().String(),
+		})
+		conn := telnet.Server(logger.traceConnection(tcpconn))
 		go func() {
 			defer conn.Close()
 			log.Printf("%s connected", conn.RemoteAddr())
-			session := newSession(conn, *password)
+			session := newSession(conn, *password, logger)
 			session.negotiateOptions()
 			session.runForever()
 			log.Printf("%s disconnected", conn.RemoteAddr())

--- a/proxy.go
+++ b/proxy.go
@@ -17,14 +17,8 @@ import (
 const historySize = 20 * 1024 // about 256 lines of text
 const logSepFormat = "2006-01-02 15:04:05 -0700 MST"
 
-type Proxy interface {
-	io.Writer
-
-	AddDownstream(io.WriteCloser)
-}
-
 var proxiesMutex sync.Mutex
-var proxies = make(map[string]*proxyImpl)
+var proxies = make(map[string]*Proxy)
 
 func CloseAll() {
 	proxiesMutex.Lock()
@@ -34,7 +28,7 @@ func CloseAll() {
 	}
 }
 
-func ConnectProxy(key string, conn telnet.Conn, addr string, toSend []byte) (Proxy, error) {
+func ConnectProxy(key string, conn telnet.Conn, addr string, toSend []byte) (*Proxy, error) {
 	proxy, isNew := findProxyByKey(key, logrus.Fields{
 		"type": "server",
 		"peer": addr,
@@ -72,7 +66,7 @@ func ReopenLogFiles() {
 	}
 }
 
-type proxyImpl struct {
+type Proxy struct {
 	key         string
 	mux         sync.Mutex
 	upstreamLog io.WriteCloser
@@ -81,12 +75,12 @@ type proxyImpl struct {
 	downstreams []io.WriteCloser
 }
 
-func findProxyByKey(key string, fields logrus.Fields) (*proxyImpl, bool) {
+func findProxyByKey(key string, fields logrus.Fields) (*Proxy, bool) {
 	proxiesMutex.Lock()
 	defer proxiesMutex.Unlock()
 	_, found := proxies[key]
 	if !found {
-		proxies[key] = &proxyImpl{key: key, log: newLogrusLogger(log, fields)}
+		proxies[key] = &Proxy{key: key, log: newLogrusLogger(log, fields)}
 	}
 	return proxies[key], !found
 }
@@ -97,21 +91,21 @@ func removeProxyByKey(key string) {
 	delete(proxies, key)
 }
 
-func (p *proxyImpl) AddDownstream(downstream io.WriteCloser) {
+func (p *Proxy) AddDownstream(downstream io.WriteCloser) {
 	p.mux.Lock()
 	defer p.mux.Unlock()
 	p.downstreams = append(p.downstreams, downstream)
 }
 
-func (p *proxyImpl) Read(bytes []byte) (n int, err error) {
+func (p *Proxy) Read(bytes []byte) (n int, err error) {
 	return p.log.traceIO("Read", p.upstream.Read, bytes)
 }
 
-func (p *proxyImpl) Write(bytes []byte) (n int, err error) {
+func (p *Proxy) Write(bytes []byte) (n int, err error) {
 	return p.log.traceIO("Write", p.upstream.Write, bytes)
 }
 
-func (p *proxyImpl) connect(addr string) (err error) {
+func (p *Proxy) connect(addr string) (err error) {
 	p.upstream, err = telnet.Dial(addr)
 	if err != nil {
 		return
@@ -121,14 +115,14 @@ func (p *proxyImpl) connect(addr string) (err error) {
 	return
 }
 
-func (p *proxyImpl) Close() error {
+func (p *Proxy) Close() error {
 	p.closeUpstream()
 	p.closeDownstreams()
 	p.closeLog()
 	return nil
 }
 
-func (p *proxyImpl) closeDownstreams() {
+func (p *Proxy) closeDownstreams() {
 	p.mux.Lock()
 	defer p.mux.Unlock()
 	for _, downstream := range p.downstreams {
@@ -136,7 +130,7 @@ func (p *proxyImpl) closeDownstreams() {
 	}
 }
 
-func (p *proxyImpl) closeLog() {
+func (p *Proxy) closeLog() {
 	p.mux.Lock()
 	defer p.mux.Unlock()
 	t := time.Now()
@@ -144,20 +138,20 @@ func (p *proxyImpl) closeLog() {
 	p.upstreamLog.Close()
 }
 
-func (p *proxyImpl) closeUpstream() {
+func (p *Proxy) closeUpstream() {
 	p.mux.Lock()
 	defer p.mux.Unlock()
 	p.upstream.Close()
 }
 
-func (p *proxyImpl) logFileName() string {
+func (p *Proxy) logFileName() string {
 	return path.Join(
 		*logdir,
 		fmt.Sprintf("%s-%s.log", time.Now().Format("2006-01-02"), p.key),
 	)
 }
 
-func (p *proxyImpl) negotiateOptions() {
+func (p *Proxy) negotiateOptions() {
 	for _, opt := range []telnet.Option{
 		telnet.NewSuppressGoAheadOption(),
 		telnet.NewTransmitBinaryOption(),
@@ -193,7 +187,7 @@ func (p *proxyImpl) negotiateOptions() {
 
 const bannerLogOpened = "--------------- opened"
 
-func (p *proxyImpl) openLog() error {
+func (p *Proxy) openLog() error {
 	log, err := os.OpenFile(
 		p.logFileName(),
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY,
@@ -210,7 +204,7 @@ func (p *proxyImpl) openLog() error {
 	return err
 }
 
-func (p *proxyImpl) readHistory() ([]byte, error) {
+func (p *Proxy) readHistory() ([]byte, error) {
 	file, err := os.Open(p.logFileName())
 	if err != nil {
 		return nil, err
@@ -248,12 +242,12 @@ func (p *proxyImpl) readHistory() ([]byte, error) {
 	return buf, nil
 }
 
-func (p *proxyImpl) reopenLog() error {
+func (p *Proxy) reopenLog() error {
 	p.closeLog()
 	return p.openLog()
 }
 
-func (p *proxyImpl) runForever() {
+func (p *Proxy) runForever() {
 	defer removeProxyByKey(p.key)
 	defer p.Close()
 	for {
@@ -274,7 +268,7 @@ func (p *proxyImpl) runForever() {
 	}
 }
 
-func (p *proxyImpl) sendDownstream(buf []byte) {
+func (p *Proxy) sendDownstream(buf []byte) {
 	p.mux.Lock()
 	defer p.mux.Unlock()
 	i := 0
@@ -290,7 +284,7 @@ func (p *proxyImpl) sendDownstream(buf []byte) {
 	p.downstreams = p.downstreams[:i]
 }
 
-func (p *proxyImpl) writeLog(buf []byte) (int, error) {
+func (p *Proxy) writeLog(buf []byte) (int, error) {
 	p.mux.Lock()
 	defer p.mux.Unlock()
 	return p.upstreamLog.Write(buf)

--- a/session.go
+++ b/session.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"strings"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stesla/telnet"
 	"golang.org/x/text/encoding/unicode"
 )
@@ -21,14 +20,11 @@ type session struct {
 	password string
 }
 
-func newSession(client telnet.Conn, password string) *session {
+func newSession(client telnet.Conn, password string, log *logrusLogger) *session {
 	session := &session{
 		Conn:     client,
 		password: password,
-		log: newLogrusLogger(log, logrus.Fields{
-			"type": "client",
-			"peer": client.RemoteAddr().String(),
-		}),
+		log:      log,
 	}
 	session.Conn.SetLogger(session.log)
 	session.Scanner = bufio.NewScanner(session)
@@ -122,12 +118,4 @@ func (s *session) isAuthenticated() bool {
 		return s.Text() == "login "+s.password
 	}
 	return false
-}
-
-func (s *session) Read(bytes []byte) (n int, err error) {
-	return s.log.traceIO("Read", s.Conn.Read, bytes)
-}
-
-func (s *session) Write(bytes []byte) (n int, err error) {
-	return s.log.traceIO("Write", s.Conn.Write, bytes)
 }

--- a/session.go
+++ b/session.go
@@ -80,7 +80,7 @@ func (s *session) runForever() {
 	io.Copy(proxy, s)
 }
 
-func (s *session) connectProxy() (Proxy, error) {
+func (s *session) connectProxy() (*Proxy, error) {
 	var buf bytes.Buffer
 	for s.Scan() {
 		line := s.Text()


### PR DESCRIPTION
Ares has a broken telnet implementation, and it was unclear to me exactly how. This brokenness is what derailed envoy development in the past. As it turns out there's two pieces:

1. It does not handle go ahead correctly. If it is sent IAC GA, it interprets them as characters sent as input. It also does not ever respond to telnet negotiiation about this option.
2. It does not handle CHARSET properly. It gets confused about subnegotiation requests from the client, but more importantly refuses to enable the Binary option. According to CHARSET, that means it should not actually enable anything other than NVT-ASCII. An option was added to the telnet library to allow charset without binary mode being enabled.